### PR TITLE
Adds option for recursively allowing additional props

### DIFF
--- a/src/deep-equals.ts
+++ b/src/deep-equals.ts
@@ -8,7 +8,8 @@ interface ErrorWithPath extends Error {
 }
 
 export interface Options {
-  strict?: boolean
+  strict?: boolean,
+  allowAdditionalProps?: boolean,
 }
 
 type InternalComparisonFunction = (actual: any) => true | Error
@@ -93,7 +94,7 @@ export function satisfies(compare: UserComparisonFunction): Comparison {
 
 export function deepEquals(actual: any, expected: any, path: Array<string | number>, opts: Options = {}): true | Error {
   let result: true | Error
-  let allowAdditionalProps: boolean = false
+  let allowAdditionalProps: boolean = opts.allowAdditionalProps === true
 
   if (expected && expected[$any]) {
     if (typeof expected === "object" && Object.keys(expected).length > 0) {

--- a/test/functional.test.ts
+++ b/test/functional.test.ts
@@ -99,3 +99,15 @@ test("can compare recursive data structures", t => {
     foo: assert.satisfies(foo => assert.deepEquals(foo, { parent: foo }))
   }))
 })
+
+test("can match on subsets", t => {
+  assert.deepEquals({foo: {bar: "baz", extra: true}, extra: true}, {foo: {bar: "baz"}}, {allowAdditionalProps: true})
+  t.pass()
+})
+
+test("subsets only match when option is passed", t => {
+  t.throws(() => assert.deepEquals(
+    {foo: {bar: "baz", extra: true}, extra: true},
+    {foo: {bar: "baz"}}
+  ))
+})


### PR DESCRIPTION
This PR adds an option for recursively applying `allowAdditionalProps`, effectively making it possible to match on an object subset without having to splat `any()` on every single nested object.

Example:

```js
assert.deepEquals(
  {foo: {bar: "baz", extra: true}, extra: true},
  {foo: {bar: "baz"}},
  {allowAdditionalProps: true})
```

I realize that this library hasn't been updated in awhile, so no worries if you aren't interested in accepting this. Feel free to close, I'm happy to just make a fork if that's easier.